### PR TITLE
shade json4s in scalalistener

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "build:lib": "tsc -p tsconfig.lab.json",
         "build:labextension": "jupyter labextension build .",
         "build:labextension:dev": "jupyter labextension build --development True .",
-        "build:scalalistener": "cd scalalistener && sbt +package",
+        "build:scalalistener": "cd scalalistener && sbt +assembly",
         "clean": "rimraf lib jupyterlab_sparkmonior:labextension",
         "clean:all": "jlpm run clean:lib && jlpm run clean:labextension",
         "watch": "run-p watch:src watch:labextension",

--- a/scalalistener/build.sbt
+++ b/scalalistener/build.sbt
@@ -54,6 +54,6 @@ assembly / assemblyOutputPath := {
 }
 
 ThisBuild / assemblyShadeRules := Seq(
-  ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.@1").inAll
+  ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.org.json4s.@1").inAll
 )
 ThisBuild / assemblyPackageScala / assembleArtifact := false,

--- a/scalalistener/build.sbt
+++ b/scalalistener/build.sbt
@@ -2,32 +2,58 @@ name := "sparkmonitor"
 
 version := "1.0"
 
-scalaVersion := "2.12.10"
-crossScalaVersions := Seq("2.11.12", "2.12.10")
-
+scalaVersion := "2.12.15"
+crossScalaVersions := Seq("2.11.12", "2.12.15")
 organization := "cern"
 
 val sparkVersion2 = "2.4.7"
-val sparkVersion3 = "3.0.1"
+val sparkVersion3 = "3.2.0"
 
 libraryDependencies ++= {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 11)) => List(
-      "org.apache.spark" %% "spark-core" % sparkVersion2 ,
-      "net.sf.py4j" % "py4j" % "0.10.7" ,
-      "log4j" % "log4j" % "1.2.17" ,
+      "org.apache.spark" %% "spark-core" % sparkVersion2 % "provided",
+      "net.sf.py4j" % "py4j" % "0.10.7" % "provided",
+      "log4j" % "log4j" % "1.2.17" % "provided",
+      "org.json4s" % "json4s-ast_2.11" % "3.7.0-M5",
+      ("org.json4s" % "json4s-jackson_2.11" % "3.7.0-M5").exclude("com.fasterxml.jackson.core" , "jackson-databind"),
     )
     case Some((2, 12)) => List(
-      "org.apache.spark" %% "spark-core" % sparkVersion3 ,
-      "net.sf.py4j" % "py4j" % "0.10.7" ,
-      "log4j" % "log4j" % "1.2.17" ,
+      "org.apache.spark" %% "spark-core" % sparkVersion3 % "provided" ,
+      "net.sf.py4j" % "py4j" % "0.10.7" % "provided",
+      "log4j" % "log4j" % "1.2.17" % "provided",
+      "org.json4s" % "json4s-ast_2.12" % "3.7.0-M5",
+      ("org.json4s" % "json4s-jackson_2.12" % "3.7.0-M5").exclude("com.fasterxml.jackson.core" , "jackson-databind"),
     )
   }
 }
 
-pluginCrossBuild / artifactPath in Compile in packageBin := {
+ThisBuild / assemblyShadeRules := {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, 11)) => Seq(
+      ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.org.json4s.@1").inAll
+    )
+    case Some((2, 12)) => List(
+      ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.org.json4s.@1").inAll
+    )
+  }
+}
+
+assembly / assemblyJarName := {
+  scalaBinaryVersion.value match {
+    case "2.11" => "listener_2.11.jar"
+    case "2.12" => "listener_2.12.jar"
+  }
+}
+
+assembly / assemblyOutputPath := {
   scalaBinaryVersion.value match {
     case "2.11" => (baseDirectory { base => base / ("../sparkmonitor/listener_2.11.jar") }).value
     case "2.12" => (baseDirectory { base => base / ("../sparkmonitor/listener_2.12.jar") }).value
   }
 }
+
+ThisBuild / assemblyShadeRules := Seq(
+  ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.@1").inAll
+)
+ThisBuild / assemblyPackageScala / assembleArtifact := false,

--- a/scalalistener/project/plugins.sbt
+++ b/scalalistener/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "1.1.0")


### PR DESCRIPTION
Spark 3.2 changed version of json4s, shading helps have a single codebase compatible for spark 2.4, 3.0, 3.1, 3.2