### PR TITLE
Make colors of the spark jobs table consistent with the jupyterlab theme

### DIFF
--- a/src/components/job-table.tsx
+++ b/src/components/job-table.tsx
@@ -77,7 +77,13 @@ const JobItem = observer((props: { jobId: string }) => {
             className={
               'tdstageicon ' + (!stagesCollapsed ? 'tdstageiconcollapsed' : '')
             }
-          ></span>
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="18" viewBox="0 0 18 18">
+              <g className="jp-icon0" fill="#616161" shapeRendering="geometricPrecision">
+                <path d="M7.2,5.2L10.9,9l-3.8,3.8V5.2H7.2z"/>
+              </g>
+            </svg>
+          </span>
         </td>
         <td className="tdjobid">{job.jobId}</td>
         <td className="tdjobname">{job.name}</td>

--- a/style/jobtable.css
+++ b/style/jobtable.css
@@ -1,9 +1,5 @@
 .pm .tdstageicon {
   display: block;
-  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAAXUlEQVR4AWMAgVGwjkGKNA3/GT4wZDAwkqABDA8zaBKtAQp/MjQwsBGnAQGvMVgTpwEB/zFMZ+AjoAEDPmUIpKGGfwzTGPho5OmfDPUMbKREnAYpSSOdgZGSxDcKADdXTK1stp++AAAAAElFTkSuQmCC');
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 100%;
   width: 15px;
 
   /* display: inline-block; */
@@ -19,18 +15,18 @@
 }
 
 .pm td.stagetableoffset {
-  background-color: #e7e7e7;
+  background-color: var(--jp-layout-color0);
 }
 
 .pm th {
   white-space: nowrap;
   font-size: small;
-  background-color: #eee;
+  background-color: var(--jp-layout-color2);
   border: 0;
 }
 
 .pm td {
-  background-color: white;
+  background-color: var(--jp-layout-color0);
   border: 0;
   font-size: small;
   border-top: 1px solid rgb(84 84 84 / 8%);
@@ -66,7 +62,7 @@
 
 .pm tr .tdstagebutton:hover ~ td,
 tr .tdstagebutton:hover {
-  background-color: rgb(184 223 255 / 37%);
+  background-color: var(--jp-layout-color2);
 }
 
 .pm th.thbutton {
@@ -171,7 +167,7 @@ progress {
 }
 
 .pm .stagetable tr th {
-  background: rgb(235 235 235);
+  background: var(--jp-layout-color2);
 }
 
 .pm .cssprogress {


### PR DESCRIPTION
This patch fixes https://github.com/swan-cern/sparkmonitor/issues/30 by changing the stylesheet to use CSS variables defined by jupyter theme instead of hardcoding color values.

Light theme:
![image](https://github.com/user-attachments/assets/baec7306-e219-403a-882f-67ce3c965ed9)

Dark theme:
![image](https://github.com/user-attachments/assets/5e7177de-be37-4752-9dcd-b88dd0df3334)
