### PR TITLE
Add support for scala 2.13 and drop scala 2.11 in sparkmonitor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,15 @@ jobs:
       with:
         node-version: '20.x'
    
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: 11
+          cache: sbt
+          - uses: sbt/setup-sbt@v1
+            with:
+              sbt-runner-version: 1.9.9
 
     - name: Install dependencies 
       run: pip install build twine

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,11 +24,16 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
-   
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: 11
+          cache: sbt
+            - uses: sbt/setup-sbt@v1
+              with:
+                sbt-runner-version: 1.9.9
 
     - name: Install dependencies 
       run: pip install build twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ ensured-targets = [
     "sparkmonitor/labextension/static/style.js",
     "sparkmonitor/labextension/package.json",
     "sparkmonitor/nbextension/extension.js",
-    "sparkmonitor/listener_2.11.jar",
+    "sparkmonitor/listener_2.13.jar",
     "sparkmonitor/listener_2.12.jar",
 ]
 skip-if-exists = ["sparkmonitor/labextension/static/style.js"]

--- a/scalalistener/build.sbt
+++ b/scalalistener/build.sbt
@@ -1,59 +1,15 @@
 name := "sparkmonitor"
 
-version := "1.0"
+version := "1.1"
 
-scalaVersion := "2.12.15"
-crossScalaVersions := Seq("2.11.12", "2.12.15")
+scalaVersion := "2.12.18"
+crossScalaVersions := Seq("2.12.18", "2.13.8")
 organization := "cern"
+licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-val sparkVersion2 = "2.4.7"
-val sparkVersion3 = "3.0.1"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.5.5"
 
-libraryDependencies ++= {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 11)) => List(
-      "org.apache.spark" %% "spark-core" % sparkVersion2 % "provided",
-      "net.sf.py4j" % "py4j" % "0.10.7" % "provided",
-      "log4j" % "log4j" % "1.2.17" % "provided",
-      "org.json4s" % "json4s-ast_2.11" % "3.7.0-M5",
-      ("org.json4s" % "json4s-jackson_2.11" % "3.7.0-M5").exclude("com.fasterxml.jackson.core" , "jackson-databind"),
-    )
-    case Some((2, 12)) => List(
-      "org.apache.spark" %% "spark-core" % sparkVersion3 % "provided" ,
-      "net.sf.py4j" % "py4j" % "0.10.7" % "provided",
-      "log4j" % "log4j" % "1.2.17" % "provided",
-      "org.json4s" % "json4s-ast_2.12" % "3.7.0-M5",
-      ("org.json4s" % "json4s-jackson_2.12" % "3.7.0-M5").exclude("com.fasterxml.jackson.core" , "jackson-databind"),
-    )
-  }
+Compile / packageBin / artifactPath := {
+  val scalaBin = CrossVersion.binaryScalaVersion(scalaVersion.value)
+  file(s"../sparkmonitor/listener_$scalaBin.jar")
 }
-
-ThisBuild / assemblyShadeRules := {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 11)) => Seq(
-      ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.org.json4s.@1").inAll
-    )
-    case Some((2, 12)) => List(
-      ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.org.json4s.@1").inAll
-    )
-  }
-}
-
-assembly / assemblyJarName := {
-  scalaBinaryVersion.value match {
-    case "2.11" => "listener_2.11.jar"
-    case "2.12" => "listener_2.12.jar"
-  }
-}
-
-assembly / assemblyOutputPath := {
-  scalaBinaryVersion.value match {
-    case "2.11" => (baseDirectory { base => base / ("../sparkmonitor/listener_2.11.jar") }).value
-    case "2.12" => (baseDirectory { base => base / ("../sparkmonitor/listener_2.12.jar") }).value
-  }
-}
-
-ThisBuild / assemblyShadeRules := Seq(
-  ShadeRule.rename("org.json4s.**" -> "ch.cern.swan.org.json4s.@1").inAll
-)
-ThisBuild / assemblyPackageScala / assembleArtifact := false,

--- a/scalalistener/project/plugins.sbt
+++ b/scalalistener/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n"      % "sbt-assembly"    % "1.1.0")

--- a/sparkmonitor/kernelextension.py
+++ b/sparkmonitor/kernelextension.py
@@ -203,8 +203,8 @@ def configure(conf):
     os.environ['SPARKMONITOR_KERNEL_PORT'] = str(port)
     logger.info(os.environ['SPARKMONITOR_KERNEL_PORT'])
     spark_scala_version = get_spark_scala_version()
-    if "2.11" in spark_scala_version:
-        jarpath = os.path.abspath(os.path.dirname(__file__)) + "/listener_2.11.jar"
+    if "2.13" in spark_scala_version:
+        jarpath = os.path.abspath(os.path.dirname(__file__)) + "/listener_2.13.jar"
         logger.info('Adding jar from %s ', jarpath)
         conf.set('spark.driver.extraClassPath', jarpath)
         conf.set('spark.extraListeners', 'sparkmonitor.listener.JupyterSparkMonitorListener')


### PR DESCRIPTION
Summary:
Implement cross-compilation support for Scala 2.12 and Scala 2.13 in SparkMonitor, while removing the legacy Scala 2.11 support.

Details:

Legacy Removal:

Scala 2.11 was used for Spark 2.x and is no longer relevant.
Dropping Scala 2.11 support will simplify the build process by eliminating associated workarounds.
Cross-Compilation Updates:

Introduce cross-compilation for Scala 2.12 and Scala 2.13.
Scala 2.12 is currently deployed with Spark 3.x.
Scala 2.13 support is required for the upcoming Spark 4.0.
Kernel Extension Package:

Update the kernel extension package to ensure compatibility with both Scala 2.12 and Scala 2.13.
This update streamlines the build and ensures that SparkMonitor is aligned with current and future Spark deployments.