### PR TITLE
Replace deprecated pip-action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-      - uses: BSFishy/pip-action@v1
-        with:
-          packages: |
-            bump2version
+      - name: Install release tooling
+        run: python -m pip install bump2version
       - name: Bump and tag
         run: |
           git config --local user.email "swan-admins@cern.ch"


### PR DESCRIPTION
Replace deprecated pip-action in release workflow