### PR TITLE
Buffer messages to the frontend until the comm opens

### DIFF
--- a/sparkmonitor/kernelextension.py
+++ b/sparkmonitor/kernelextension.py
@@ -11,7 +11,7 @@ import logging
 import os
 import socket
 from pathlib import Path
-from threading import Thread
+from threading import Lock, Thread
 
 ipykernel_imported = True
 spark_imported = True
@@ -40,6 +40,9 @@ class ScalaMonitor:
         ipython is the instance of ZMQInteractiveShell
         """
         self.ipython = ipython
+        self.comm = None
+        self.comm_lock = Lock()
+        self.pending = []
 
     def start(self):
         """Creates the socket thread and returns assigned port"""
@@ -51,8 +54,16 @@ class ScalaMonitor:
         return self.scalaSocket.port
 
     def send(self, msg):
-        """Send a message to the frontend"""
-        self.comm.send(msg)
+        """Send a message to the frontend, buffering until the comm opens.
+
+        May be called from any thread; sends and buffer access are
+        serialized with the buffer flush in target_func.
+        """
+        with self.comm_lock:
+            if self.comm is None:
+                self.pending.append(msg)
+            else:
+                self.comm.send(msg)
 
     def handle_comm_message(self, msg):
         """Handle message received from frontend
@@ -70,12 +81,19 @@ class ScalaMonitor:
     def target_func(self, comm, msg):
         """Callback function to be called when a frontend comm is opened"""
         logger.info('SparkMonitor comm opened from frontend.')
-        self.comm = comm
 
-        @self.comm.on_msg
+        @comm.on_msg
         def _recv(msg):
             self.handle_comm_message(msg)
         comm.send({'msgtype': 'commopen'})
+        # flush buffered messages and only then publish the comm, so direct
+        # sends cannot overtake the flush or reach a frontend that has not
+        # received commopen yet
+        with self.comm_lock:
+            for pending_msg in self.pending:
+                comm.send(pending_msg)
+            self.pending = []
+            self.comm = comm
 
 
 class SocketThread(Thread):

--- a/tests/test_kernelextension.py
+++ b/tests/test_kernelextension.py
@@ -1,5 +1,9 @@
+import logging
+from threading import Thread
+
 import pytest
 
+from sparkmonitor import kernelextension
 from sparkmonitor.kernelextension import (
     get_listener_jar_path,
     get_spark_versions,
@@ -49,3 +53,72 @@ class TestGetListenerJarPath:
 
     def test_unknown_scala_version_returns_empty_path(self):
         assert get_listener_jar_path("3", "2.11") == ""
+
+
+class FakeComm:
+    """Records messages sent to the frontend."""
+
+    def __init__(self):
+        self.sent = []
+
+    def send(self, msg):
+        self.sent.append(msg)
+
+    def on_msg(self, callback):
+        return callback
+
+
+@pytest.fixture
+def monitor(monkeypatch):
+    monkeypatch.setattr(kernelextension, "logger", logging.getLogger("test"), raising=False)
+    return kernelextension.ScalaMonitor(ipython=None)
+
+
+class TestScalaMonitorComm:
+    def test_send_before_comm_opens_is_buffered(self, monitor):
+        monitor.send({"msgtype": "early"})
+        assert monitor.pending == [{"msgtype": "early"}]
+
+    def test_commopen_is_sent_before_buffered_messages(self, monitor):
+        monitor.send({"msgtype": "early"})
+        comm = FakeComm()
+        monitor.target_func(comm, msg=None)
+        assert comm.sent == [{"msgtype": "commopen"}, {"msgtype": "early"}]
+
+    def test_buffer_is_emptied_after_flush(self, monitor):
+        monitor.send({"msgtype": "early"})
+        monitor.target_func(FakeComm(), msg=None)
+        assert monitor.pending == []
+
+    def test_send_after_comm_opens_goes_directly_to_the_comm(self, monitor):
+        comm = FakeComm()
+        monitor.target_func(comm, msg=None)
+        monitor.send({"msgtype": "late"})
+        assert comm.sent == [{"msgtype": "commopen"}, {"msgtype": "late"}]
+
+    def test_send_during_flush_is_delivered_after_buffered_messages(self, monitor):
+        """A message arriving while the buffer is being flushed must wait for
+        the flush and be delivered afterwards, not lost or reordered."""
+        monitor.send({"msgtype": "early"})
+
+        senders = []
+
+        class CommOpenedDuringSend(FakeComm):
+            def send(self, msg):
+                super().send(msg)
+                if msg == {"msgtype": "early"}:
+                    # a concurrent send during the flush blocks until the
+                    # flush completes because target_func holds the lock
+                    sender = Thread(target=monitor.send, args=({"msgtype": "during-flush"},))
+                    sender.start()
+                    senders.append(sender)
+
+        comm = CommOpenedDuringSend()
+        monitor.target_func(comm, msg=None)
+        for sender in senders:
+            sender.join(timeout=10)
+        assert comm.sent == [
+            {"msgtype": "commopen"},
+            {"msgtype": "early"},
+            {"msgtype": "during-flush"},
+        ]


### PR DESCRIPTION
Fixes #7.

If spark events arrive before the frontend opens the SparkMonitor comm,
`ScalaMonitor.send` raises `AttributeError`, killing event forwarding for
the lifetime of the kernel. See #7 for details and diagnosis.

This change buffers messages while the comm is unset and flushes them once
the frontend opens the comm — the same approach as #32, with the
synchronization concerns from its review addressed:

- all buffer access and post-open sends take a lock, so `send` on the
  socket thread cannot mutate the buffer while `target_func` is flushing it
- `commopen` is sent and the buffer is flushed *before* `self.comm` is
  published (last, under the lock), so a concurrent send can neither
  overtake the flush nor reach a frontend that has not finished its comm
  initialization

Events from the race window are delivered rather than lost, so the monitor
renders jobs that started before the frontend attached.

Unit tests cover both scenarios raised in the #32 review: a message
arriving before the comm opens, and a message arriving mid-flush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)